### PR TITLE
update ncio version to 1.1.2

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -8,7 +8,7 @@ defaults:
     shell: bash -leo pipefail {0}
 
 env:
-  cache_key: gcc1  # The number (#) following the cache_key "gcc" is to flush Action cache.
+  cache_key: gcc2  # The number (#) following the cache_key "gcc" is to flush Action cache.
   CC: gcc-10
   FC: gfortran-10
   CXX: g++-10

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,7 +9,7 @@ defaults:
 
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: intel1  # The number (#) following the cache_key "intel" is to flush Action cache.
+  cache_key: intel2  # The number (#) following the cache_key "intel" is to flush Action cache.
   CC: icc
   FC: ifort
   CXX: icpc

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -18,7 +18,7 @@ spack:
   - sfcio@1.4.1
   - nemsio@2.5.2
   - wrf-io@1.2.0
-  - ncio@1.0.0
+  - ncio@1.1.2
   - gsi-ncdiag@1.0.0
   view: true
   concretizer:

--- a/modulefiles/gsiutils_common.lua
+++ b/modulefiles/gsiutils_common.lua
@@ -13,7 +13,7 @@ local sigio_ver=os.getenv("sigio_ver") or "2.3.2"
 local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
 local nemsio_ver=os.getenv("nemsio_ver") or "2.5.2"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
-local ncio_ver=os.getenv("ncio_ver") or "1.0.0"
+local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.0.0"
 
 load(pathJoin("netcdf", netcdf_ver))

--- a/modulefiles/gsiutils_wcoss2.lua
+++ b/modulefiles/gsiutils_wcoss2.lua
@@ -19,10 +19,14 @@ load(pathJoin("python", python_ver))
 load(pathJoin("prod_util", prod_util_ver))
 
 load("gsiutils_common")
+unload("ncio")
 unload("ncdiag")
 
 pushenv("HPC_OPT", "/apps/ops/para/libs")
 prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304")
 prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
+
+load("ncio/1.1.2")
+load("ncdiag/1.0.0")
 
 whatis("Description: GSI utilities environment on WCOSS2")


### PR DESCRIPTION
`ncio` was updated to 1.1.2 to fix some bugs in reading the updated model output.
This was missed when the GSI was updated, and the utilities were split.
This PR fixes that.