### PR TITLE
Update interp_inc to allow hdf5 >=1.10.9

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -53,7 +53,7 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          git clone -c feature.manyFiles=true https://github.com/NOAA-EMC/spack.git
+          git clone -c feature.manyFiles=true https://github.com/spack/spack.git
           source spack/share/spack/setup-env.sh
           spack env create gsiutils-env GSI-utils/ci/spack.yaml
           spack env activate gsiutils-env
@@ -61,7 +61,7 @@ jobs:
           spack external find
           spack add mpich@3.4.2
           spack concretize
-          spack install --dirty -v
+          spack install -v --fail-fast
 
   build:
     needs: setup

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -53,7 +53,7 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
           spack env create gsiutils-env GSI-utils/ci/spack.yaml
           spack env activate gsiutils-env

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -45,7 +45,7 @@ jobs:
             spack
             ~/.spack
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-4
 
       - name: install-intel-compilers
         if: steps.cache-env.outputs.cache-hit != 'true'
@@ -99,7 +99,7 @@ jobs:
             spack
             ~/.spack
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-4
 
       - name: build-gsiutils
         run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -67,7 +67,7 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          git clone -c feature.manyFiles=true https://github.com/NOAA-EMC/spack.git
+          git clone -c feature.manyFiles=true https://github.com/spack/spack.git
           source spack/share/spack/setup-env.sh
           spack env create gsiutils-env GSI-utils/ci/spack.yaml
           spack env activate gsiutils-env
@@ -75,7 +75,7 @@ jobs:
           spack external find
           spack add intel-oneapi-mpi
           spack concretize
-          spack install --dirty -v
+          spack install --fail-fast -v
 
   build:
     needs: setup

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -67,7 +67,7 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
           spack env create gsiutils-env GSI-utils/ci/spack.yaml
           spack env activate gsiutils-env

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -45,7 +45,7 @@ jobs:
             spack
             ~/.spack
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-2
 
       - name: install-intel-compilers
         if: steps.cache-env.outputs.cache-hit != 'true'
@@ -71,6 +71,7 @@ jobs:
           source spack/share/spack/setup-env.sh
           spack env create gsiutils-env GSI-utils/ci/spack.yaml
           spack env activate gsiutils-env
+          sudo mv /usr/local/ /usr/local_mv
           spack compiler find
           spack external find
           spack add intel-oneapi-mpi
@@ -99,7 +100,7 @@ jobs:
             spack
             ~/.spack
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-2
 
       - name: build-gsiutils
         run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,7 +9,7 @@ defaults:
 
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: intel4  # The number (#) following the cache_key "intel" is to flush Action cache.
+  cache_key: intel5  # The number (#) following the cache_key "intel" is to flush Action cache.
   CC: icc
   FC: ifort
   CXX: icpc
@@ -39,13 +39,13 @@ jobs:
       # Cache spack, compiler and dependencies
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             spack
             ~/.spack
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-4
+          key: spack-${{ runner.os }}-${{ env.cache_key }}
 
       - name: install-intel-compilers
         if: steps.cache-env.outputs.cache-hit != 'true'
@@ -94,13 +94,13 @@ jobs:
 
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             spack
             ~/.spack
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-4
+          key: spack-${{ runner.os }}-${{ env.cache_key }}
 
       - name: build-gsiutils
         run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -67,7 +67,7 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
+          git clone -c feature.manyFiles=true https://github.com/spack/spack.git
           source spack/share/spack/setup-env.sh
           spack env create gsiutils-env GSI-utils/ci/spack.yaml
           spack env activate gsiutils-env
@@ -75,7 +75,7 @@ jobs:
           spack external find
           spack add intel-oneapi-mpi
           spack concretize
-          spack install --fail-fast -v
+          spack install --dirty --fail-fast -v
 
   build:
     needs: setup

--- a/src/EnKF/gfs/src/recentersigp.fd/recentersigp.f90
+++ b/src/EnKF/gfs/src/recentersigp.fd/recentersigp.f90
@@ -66,8 +66,8 @@ program recentersigp
   type(Dataset) :: dseti,dseto,dsetmi,dsetmo,dsetmg
   type(Dimension) :: londim,latdim,levdim
 
-  namelist /recenter/ incvars_to_zero
   character(len=12),dimension(10) :: incvars_to_zero !just picking 10 arbitrarily
+  namelist /recenter/ incvars_to_zero
 
 ! Initialize mpi
   call MPI_Init(ierr)

--- a/src/netcdf_io/interp_inc.fd/driver.f90
+++ b/src/netcdf_io/interp_inc.fd/driver.f90
@@ -91,9 +91,9 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
 ! with data below.
 !-----------------------------------------------------------------
 
- if (mype == 0)  call w3tagb('INTERP_INC', 2019, 100, 0, 'EMC')
+ if (mype == npes-1)  call w3tagb('INTERP_INC', 2019, 100, 0, 'EMC')
 
- if (mype == 0) print*,'- READ SETUP NAMELIST'
+ if (mype == npes-1) print*,'- READ SETUP NAMELIST'
  open (43, file="./fort.43")
  read (43, nml=setup, iostat=error)
  if (error /= 0) then
@@ -102,7 +102,7 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
  endif
  close (43)
 
- if (mype == 0) print*,"- WILL INTERPOLATE TO GAUSSIAN GRID OF DIMENSION ",lon_out, lat_out
+ if (mype == npes-1) print*,"- WILL INTERPOLATE TO GAUSSIAN GRID OF DIMENSION ",lon_out, lat_out
 
 ! Set constants
  rad2deg = 180.0_8 / (4.0_8 * atan(1.0_8))
@@ -111,7 +111,7 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
  ilev=lev+1
 
  call mpi_barrier(mpi_comm_world, mpierr)
- if (mype == 0) then
+ if (mype == npes-1) then
    print*,'- OPEN OUTPUT FILE: ', trim(outfile)
   
    error = nf90_create(outfile, cmode=IOR(NF90_CLOBBER,NF90_NETCDF4), ncid=ncid_out)
@@ -243,7 +243,7 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
 ! Open and read input file
 !----------------------------------------------------
 
- if (mype == 0) print*,'- OPEN INPUT FILE: ', trim(infile)
+ if (mype == npes-1) print*,'- OPEN INPUT FILE: ', trim(infile)
 
  error = nf90_open(trim(infile), ior(nf90_nowrite, nf90_mpiio), &
                    comm=mpi_comm_world, info = mpi_info_null, ncid=ncid_in)
@@ -338,7 +338,7 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
    ! skip v_inc (done with u_inc, which comes first)
    if (trim(records(rec)) .eq. 'v_inc') cycle
 
-   if (mype == rec) then
+   if (mype == rec-1) then
      print*,'- PROCESS RECORD: ', trim(records(rec))
   
      error = nf90_inq_varid(ncid_in, trim(records(rec)), id_var)
@@ -379,9 +379,9 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
           stop 77
         endif
         call mpi_send(go(1,1), size(go), mpi_double_precision, &
-                      0, 1000+rec, mpi_comm_world, mpierr)
+                      npes-1, 1000+rec, mpi_comm_world, mpierr)
         call mpi_send(go3(1,1), size(go3), mpi_double_precision, &
-                      0, 2000+rec, mpi_comm_world, mpierr)
+                      npes-1, 2000+rec, mpi_comm_world, mpierr)
      else
         call ipolates(ip, ipopt, kgds_in, kgds_out, mi, mo, &
                    lev, ibi, li, gi, no, rlat, rlon, ibo, &
@@ -397,12 +397,12 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
         !dummy_out = reshape(go, (/lon_out,lat_out,lev/))
         !print *, lon_out, lat_out, lev, 'send'
         call mpi_send(go(1,1), size(go), mpi_double_precision, &
-                      0, 1000+rec, mpi_comm_world, mpierr)
+                      npes-1, 1000+rec, mpi_comm_world, mpierr)
      endif
-   else if (mype == 0) then
+   else if (mype == npes-1) then
      !print *, lon_out, lat_out, lev, 'recv'
      call mpi_recv(go2(1,1), size(go2), mpi_double_precision, &
-                   rec, 1000+rec, mpi_comm_world, mpistat, mpierr)
+                   rec-1, 1000+rec, mpi_comm_world, mpistat, mpierr)
      dummy_out = reshape(go2, (/lon_out,lat_out,lev/))
      error = nf90_inq_varid(ncid_out, trim(records(rec)), id_var)
      call netcdf_err(error, 'inquiring ' // trim(records(rec)) // ' id for file='//trim(outfile) )
@@ -411,7 +411,7 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
      if (trim(records(rec)) .eq. 'u_inc') then
         ! process v_inc also.
         call mpi_recv(go2(1,1), size(go2), mpi_double_precision, &
-                      rec, 2000+rec, mpi_comm_world, mpistat, mpierr)
+                      rec-1, 2000+rec, mpi_comm_world, mpistat, mpierr)
         dummy_out = reshape(go2, (/lon_out,lat_out,lev/))
         error = nf90_inq_varid(ncid_out, 'v_inc', id_var)
         call netcdf_err(error, 'inquiring v_inc id for file='//trim(outfile) )
@@ -435,7 +435,7 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
 ! Update remaining output file records according to Cory's sample.
 !------------------------------------------------------------------
 
- if (mype == 0) then
+ if (mype == npes-1) then
    print*,"- WRITE OUTPUT FILE: ", trim(outfile)
   
   ! lev
@@ -490,9 +490,9 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
  end if
 
  call mpi_barrier(mpi_comm_world, mpierr)
- if (mype == 0) print*,'- NORMAL TERMINATION'
+ if (mype == npes-1) print*,'- NORMAL TERMINATION'
 
- if (mype == 0) call w3tage('INTERP_INC')
+ if (mype == npes-1) call w3tage('INTERP_INC')
  call mpi_barrier(mpi_comm_world, mpierr)
  call mpi_finalize(mpierr)
 


### PR DESCRIPTION
This PR modifies src/netcdf_io/interp_inc.fd/driver.f90 to allow it to run with hdf5 1.10.9 and later. As of 1.10.9, certain MPI-based hdf5 functions must have the root MPI process (`mype==0`) available in order to run. In the current code, as discovered by @KateFriedman-NOAA, this causes interp_inc.x to hang in the `nf90_inq_varid` function. This PR takes the last (`npes-1`) MPI proc and makes it the command-and-control task instead of proc 0. Tested with Global Workflow on Orion.