### PR TITLE
Update Jet modulefiles to Rocky8

### DIFF
--- a/modulefiles/gsiutils_jet.intel.lua
+++ b/modulefiles/gsiutils_jet.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local python_ver=os.getenv("python_ver") or "3.11.6"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"


### PR DESCRIPTION
**Description**

- Jet has been upgraded to the Rocky8 Linux OS and present module file no longer works
- Update Jet module file to use Rocky8 installation of spack-stack;

Fixes #33
Refs NOAA-EMC/global-workflow#2377


**How Has This Been Tested?**

This change affects only Jet, there is no need to test on other systems
Cycled experiments (48+ hours) at resolutions
- [x] 96/48 on xjet and kjet
- [x] 192/96 on kjet
- [x] 384/192 on kjet