### PR TITLE
Allow calc_analysis.x to switch between JEDI and GSI-formatted increments in calc_analysis.nml

### DIFF
--- a/src/netcdf_io/calc_analysis.fd/init_calc_analysis.f90
+++ b/src/netcdf_io/calc_analysis.fd/init_calc_analysis.f90
@@ -14,7 +14,7 @@ contains
     !! read in namelist parameters from
     !! calc_analysis.nml file in same directory
     !! as executable
-    use vars_calc_analysis, only: anal_file, fcst_file, incr_file, use_nemsio_anl, fhr, mype, npes
+    use vars_calc_analysis, only: anal_file, fcst_file, incr_file, use_nemsio_anl, fhr, mype, npes, jedi
     implicit none
     ! local variables to this subroutine
     character(len=500) :: datapath = './'
@@ -24,10 +24,11 @@ contains
     character(len=2) :: hrstr
     integer, parameter :: lunit = 10
     logical :: lexist = .false.
-    namelist /setup/ datapath, analysis_filename, firstguess_filename, increment_filename, fhr, use_nemsio_anl
+    namelist /setup/ datapath, analysis_filename, firstguess_filename, increment_filename, fhr, use_nemsio_anl, jedi
 
     fhr = 6 ! default to 6 hour cycle only
     use_nemsio_anl = .false. ! default to using netCDF for background and analysis
+    jedi = .false. ! default to GSI (not JEDI)
 
     ! read in the namelist
     inquire(file='calc_analysis.nml', exist=lexist)
@@ -64,6 +65,7 @@ contains
       else
         write(6,*) 'writing analysis in netCDF format'
       end if
+      write(6,*) 'Use JEDI format  = ', jedi
     end if
     
   end subroutine read_nml

--- a/src/netcdf_io/calc_analysis.fd/vars_calc_analysis.f90
+++ b/src/netcdf_io/calc_analysis.fd/vars_calc_analysis.f90
@@ -28,6 +28,7 @@ module vars_calc_analysis
   public :: fhr
   public :: mype, npes
   public :: levpe
+  public :: jedi
 
   character(len=500) :: anal_file, fcst_file, incr_file
   integer, dimension(7) :: idate, jdate
@@ -44,5 +45,6 @@ module vars_calc_analysis
   integer, dimension(7) :: fhrs_pe
   integer :: mype, npes
   integer, allocatable, dimension(:) :: levpe
+  logical :: jedi
 
 end module vars_calc_analysis


### PR DESCRIPTION
Because the JEDI increments will soon be produced in the Global Workflow with a time dimension, calc_analysis.x will fail, since it expects a GSI-style increment with no time dimensions. The PR adds a "jedi" parameter in calc_analysis.nml that is default set to false. When it is false, it expects no time dimension when reading and adding the increment to the background, and when it is true, it does expect a time dimension. 

I have tested this in the Global Workflow by adding and removing the time dimension for the atmospheric increment, and running calc_analysis.x in the "gdasanalcalc" job with jedi set to .true. and not set at all (defaults to false) respectively. The resulting analyses are zero diff.