### PR TITLE
enhance safeguards in getsigensmeanp_smooth and recentersigp

### DIFF
--- a/src/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
+++ b/src/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
@@ -46,7 +46,7 @@ program getsigensmeanp_smooth
                         filenameoutsprd
   character(len=16),allocatable,dimension(:) :: recnam
   integer :: iret,nlevs,ntrac,ntrunc,nanals,ngrd,k,ndims,nvar,nbits
-  integer :: nsize,nsize2,nsize3,nsize3t,iargc
+  integer :: nsize,nsize2,nsize3,nsize3t
   integer :: mype,mype1,npe,orig_group,new_group,new_comm
   integer :: nrec,latb,lonb,npts,n,idrt
   integer,allocatable,dimension(:) :: new_group_members,reclev,krecu,krecv

--- a/src/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
+++ b/src/EnKF/gfs/src/getsigensmeanp_smooth.fd/getsigensmeanp_smooth_ncep.f90
@@ -46,7 +46,7 @@ program getsigensmeanp_smooth
                         filenameoutsprd
   character(len=16),allocatable,dimension(:) :: recnam
   integer :: iret,nlevs,ntrac,ntrunc,nanals,ngrd,k,ndims,nvar,nbits
-  integer :: nsize,nsize2,nsize3,nsize3t
+  integer :: nsize,nsize2,nsize3,nsize3t,iargc
   integer :: mype,mype1,npe,orig_group,new_group,new_comm
   integer :: nrec,latb,lonb,npts,n,idrt
   integer,allocatable,dimension(:) :: new_group_members,reclev,krecu,krecv
@@ -99,6 +99,7 @@ program getsigensmeanp_smooth
   filenameout = trim(adjustl(datapath)) // trim(adjustl(filenameout))
   ! if a 5th arg present, it's a filename to write out ensemble spread
   ! (only used for ncio)
+  write_spread_ncio = .false.
   if (iargc() > 4) then
      call getarg(5,filenameoutsprd)
      write_spread_ncio = .true.
@@ -107,7 +108,7 @@ program getsigensmeanp_smooth
   endif
 
   if ( mype == 0 ) then
-     write(6,'(a)')  'Command line input'
+     write(6,'(a,i,a)')  'Command line input for ',iargc(),' arguments'
      write(6,'(a,a)')' datapath    = ',trim(datapath)
      write(6,'(a,a)')' filenameout = ',trim(filenameout)
      write(6,'(a,a)')' fileprefix  = ',trim(fileprefix)
@@ -588,22 +589,27 @@ program getsigensmeanp_smooth
                endif
            endif ! ndims > 2
         enddo  ! nvars
-        deallocate(values_2d, values_3d, values_2d_avg, values_3d_avg)
-        deallocate(values_2d_tmp, values_3d_tmp)
+        if (allocated(values_2d)) deallocate(values_2d)
+        if (allocated(values_3d)) deallocate(values_3d)
+        if (allocated(values_2d_avg)) deallocate(values_2d_avg)
+        if (allocated(values_3d_avg)) deallocate(values_3d_avg)
+        if (allocated(values_2d_tmp)) deallocate(values_2d_tmp)
+        if (allocated(values_3d_tmp)) deallocate(values_3d_tmp)
         if (dosmooth) then
            deallocate(rwork_spc)
            call close_dataset(dseto_smooth)
         endif
         if (write_spread_ncio) then
-           deallocate(values_2d_sprd, values_3d_sprd)
+           if (allocated(values_2d_sprd)) deallocate(values_2d_sprd)
+           if (allocated(values_3d_sprd)) deallocate(values_3d_sprd)
         endif
         if (mype == 0) then
-           call close_dataset(dseto)
+           call close_dataset(dseto, errcode=iret)
            t2 = mpi_wtime()
            print *,'time to write ens mean on root',t2-t1
            write(6,'(3a,i5)')'Write ncio ensemble mean ',trim(filenameout),' iret = ', iret
            if (write_spread_ncio) then
-             call close_dataset(dseto_sprd)
+             call close_dataset(dseto_sprd, errcode=iret)
               write(6,'(3a,i5)')'Write ncio ensemble spread ',trim(filenameoutsprd),' iret = ', iret
            endif
         endif
@@ -648,18 +654,19 @@ program getsigensmeanp_smooth
               end if
            end if ! end if 3D var
         end do ! end loop through variables
-        deallocate(values_3d, values_3d_avg)
-        deallocate(values_3d_tmp)
+        if (allocated(values_3d))     deallocate(values_3d)
+        if (allocated(values_3d_avg)) deallocate(values_3d_avg)
+	if (allocated(values_3d_tmp)) deallocate(values_3d_tmp)
         if (write_spread_ncio) then
-           deallocate(values_3d_sprd)
+           if (allocated(values_3d_sprd)) deallocate(values_3d_sprd)
         endif
         if (mype == 0) then
-           call close_dataset(dseto)
+           call close_dataset(dseto,errcode=iret)
            t2 = mpi_wtime()
            print *,'time to write ens mean on root',t2-t1
            write(6,'(3a,i5)')'Write increment ensemble mean ',trim(filenameout),' iret = ', iret
            if (write_spread_ncio) then
-             call close_dataset(dseto_sprd)
+             call close_dataset(dseto_sprd,errcode=iret)
               write(6,'(3a,i5)')'Write increment ensemble spread ',trim(filenameoutsprd),' iret = ', iret
            endif
         endif

--- a/src/EnKF/gfs/src/recentersigp.fd/recentersigp.f90
+++ b/src/EnKF/gfs/src/recentersigp.fd/recentersigp.f90
@@ -303,7 +303,11 @@ program recentersigp
               call write_vardata(dseto,trim(dseti%variables(nvar)%name),values_3d)
            end if
         end do
-        deallocate(values_3d,values_3d_i,values_3d_mi,values_3d_mb,values_3d_anl)
+        if (allocated(values_3d))    deallocate(values_3d)
+        if (allocated(values_3d_i))  deallocate(values_3d_i)
+        if (allocated(values_3d_mi)) deallocate(values_3d_mi)
+        if (allocated(values_3d_mb)) deallocate(values_3d_mb)
+        if (allocated(values_3d_anl)) deallocate(values_3d_anl)
         call write_attribute(dseto,'comment','recentered analysis increment using recentersigp') 
         call close_dataset(dsetmi)
         call close_dataset(dsetmo)
@@ -369,8 +373,14 @@ program recentersigp
            endif ! ndims > 2
         enddo  ! nvars
 
-        deallocate(values_2d,values_2d_i,values_2d_mi,values_2d_mo)
-        deallocate(values_3d,values_3d_i,values_3d_mi,values_3d_mo)
+        if (allocated(values_2d)) deallocate(values_2d)
+        if (allocated(values_2d_i)) deallocate(values_2d_i)
+        if (allocated(values_2d_mi)) deallocate(values_2d_mi)
+        if (allocated(values_2d_mo)) deallocate(values_2d_mo)
+        if (allocated(values_3d)) deallocate(values_3d)
+        if (allocated(values_3d_i)) deallocate(values_3d_i)
+        if (allocated(values_3d_mi)) deallocate(values_3d_mi)
+        if (allocated(values_3d_mo)) deallocate(values_3d_mo)
         call close_dataset(dsetmi)
         call close_dataset(dsetmo)
         call close_dataset(dseti)


### PR DESCRIPTION
CI testing of g-w PR [#2592](https://github.com/NOAA-EMC/global-workflow/pull/2592) identified sections of unsafe coding in `getsigensmeanp_smooth_ncep.f90` and `recentersigp.f90`.   This PR adds safeguards these source code files which
- initialize variables before being used
- check allocate status before deallocating
- check the correct error return codes from subroutines

Resolves #40