### PR TITLE
Add logic to switch between JEDI and GSI ice increment names

### DIFF
--- a/src/EnKF/gfs/src/recentersigp.fd/recentersigp.f90
+++ b/src/EnKF/gfs/src/recentersigp.fd/recentersigp.f90
@@ -291,6 +291,9 @@ program recentersigp
               case ('icmr_inc')
                  call read_vardata(dsetmg,'icmr',values_3d_mb)
                  call read_vardata(dsetmo,'icmr',values_3d_anl)
+              case ('ice_wat_inc')
+                 call read_vardata(dsetmg,'icmr',values_3d_mb)
+                 call read_vardata(dsetmo,'icmr',values_3d_anl)
               end select
               values_3d(:,:,:) = zero
               do j=1,latb

--- a/src/netcdf_io/interp_inc.fd/driver.F90
+++ b/src/netcdf_io/interp_inc.fd/driver.F90
@@ -79,13 +79,23 @@
  logical :: jedi = .false.
  character(len=11) :: ice_inc_name
  
- ! NOTE: u_inc,v_inc must be consecutive
- data records /'u_inc', 'v_inc', 'delp_inc', 'delz_inc', 'T_inc', &
-               'sphum_inc', 'liq_wat_inc', 'o3mr_inc', 'icmr_inc' /
-
  namelist /setup/ lon_out, lat_out, outfile, infile, lev, jedi
 
+!----------------------------------------------------------------
+! Set increment variable names.
+!----------------------------------------------------------------
 
+ ! GSI and JEDI may use difference increment variable names
+ if ( jedi ) then
+    ice_inc_name = 'icmr_inc'
+ else
+    ice_inc_name = 'ice_wat_inc'
+ end if
+ 
+ ! NOTE: u_inc,v_inc must be consecutive
+ records = (/'u_inc', 'v_inc', 'delp_inc', 'delz_inc', 'T_inc', &
+             'sphum_inc', 'liq_wat_inc', 'o3mr_inc', ice_inc_name /)
+ 
 !-----------------------------------------------------------------
 ! MPI initialization
 call mpi_init(mpierr)
@@ -116,12 +126,6 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
  dlondeg = 360.0_8 / real(lon_out,8)
 
  ilev=lev+1
-
- if ( jedi ) then
-    ice_inc_name = 'icmr_inc'
- else
-    ice_inc_name = 'ice_wat_inc'
- end if
 
  call mpi_barrier(mpi_comm_world, mpierr)
  if (mype == npes-1) then

--- a/src/netcdf_io/interp_inc.fd/driver.F90
+++ b/src/netcdf_io/interp_inc.fd/driver.F90
@@ -76,12 +76,14 @@
  real(8), allocatable :: rlon(:), rlat(:), crot(:), srot(:)
  real(8), allocatable :: gi(:,:), gi2(:,:), go(:,:), go2(:,:), go3(:,:)
 
-
+ logical :: jedi = .false.
+ character(len=11) :: ice_inc_name
+ 
  ! NOTE: u_inc,v_inc must be consecutive
  data records /'u_inc', 'v_inc', 'delp_inc', 'delz_inc', 'T_inc', &
                'sphum_inc', 'liq_wat_inc', 'o3mr_inc', 'icmr_inc' /
 
- namelist /setup/ lon_out, lat_out, outfile, infile, lev
+ namelist /setup/ lon_out, lat_out, outfile, infile, lev, jedi
 
 
 !-----------------------------------------------------------------
@@ -114,6 +116,12 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
  dlondeg = 360.0_8 / real(lon_out,8)
 
  ilev=lev+1
+
+ if ( jedi ) then
+    ice_inc_name = 'icmr_inc'
+ else
+    ice_inc_name = 'ice_wat_inc'
+ end if
 
  call mpi_barrier(mpi_comm_world, mpierr)
  if (mype == npes-1) then
@@ -185,8 +193,8 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
    error = nf90_def_var(ncid_out, 'o3mr_inc', nf90_float, (/dim_lon_out,dim_lat_out,dim_lev_out/), id_o3mr_inc_out)
    call netcdf_err(error, 'defining variable o3mr_inc for file='//trim(outfile) )
   
-   error = nf90_def_var(ncid_out, 'icmr_inc', nf90_float, (/dim_lon_out,dim_lat_out,dim_lev_out/), id_icmr_inc_out)
-   call netcdf_err(error, 'defining variable icmr_inc for file='//trim(outfile) )
+   error = nf90_def_var(ncid_out, trim(ice_inc_name), nf90_float, (/dim_lon_out,dim_lat_out,dim_lev_out/), id_icmr_inc_out)
+   call netcdf_err(error, 'defining variable ' // trim(ice_inc_name) // ' for file='//trim(outfile) )
   
    error = nf90_put_att(ncid_out, nf90_global, 'source', 'GSI')
    call netcdf_err(error, 'defining source attribute for file='//trim(outfile) )


### PR DESCRIPTION
This PR is fixes the following problem https://github.com/NOAA-EMC/GDASApp/pull/1112#issuecomment-2122874816 . It creates logic so that if JEDI is the DA system, then "ice_wat_inc" is used as the ice increment variable name, and if GSI is the DA system, then "icmr_inc" is used. A "jedi", logical namelist parameter for [src/netcdf_io/interp_inc.fd/driver.F90](https://github.com/NOAA-EMC/GSI-utils/blob/develop/src/netcdf_io/interp_inc.fd/driver.F90) is added which defaults to .false. (GSI; else JEDI). Once this PR is merged, a single line can be added to ush/calc_analysis.py, building on what was done in GW #[2420](https://github.com/NOAA-EMC/global-workflow/pull/2420) via GSI Utils #[35](https://github.com/NOAA-EMC/GSI-utils/pull/35), to specify "jedi" in the namelist.