### PR TITLE
Update wcoss2 modulefile

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -76,7 +76,7 @@ jobs:
           spack install -v --fail-fast --dirty
           spack clean --all
 
-  gsi-monitor:
+  gsi-utils:
     needs: setup
     runs-on: ubuntu-latest
 
@@ -99,10 +99,11 @@ jobs:
         run: |
           source spack/share/spack/setup-env.sh
           spack env activate gsiutils-env
-          export CC=mpicc
-          export FC=mpif90
           cd gsi-utils
           mkdir -p build && cd build
           cmake -DCMAKE_INSTALL_PREFIX=../install -DBUILD_UTIL_ALL=ON ..
           make -j2 VERBOSE=1
           make install
+        env:
+          CC: mpicc
+          FC: mpif90

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -76,7 +76,7 @@ jobs:
           spack install -v --fail-fast --dirty
           spack clean --all
 
-  gsi-utils:
+  gsi-monitor:
     needs: setup
     runs-on: ubuntu-latest
 
@@ -99,11 +99,10 @@ jobs:
         run: |
           source spack/share/spack/setup-env.sh
           spack env activate gsiutils-env
+          export CC=mpicc
+          export FC=mpif90
           cd gsi-utils
           mkdir -p build && cd build
           cmake -DCMAKE_INSTALL_PREFIX=../install -DBUILD_UTIL_ALL=ON ..
           make -j2 VERBOSE=1
           make install
-        env:
-          CC: mpicc
-          FC: mpif90

--- a/modulefiles/gsiutils_wcoss2.intel.lua
+++ b/modulefiles/gsiutils_wcoss2.intel.lua
@@ -7,20 +7,21 @@ local craype_ver=os.getenv("craype_ver") or "2.7.8"
 local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
 local python_ver=os.getenv("python_ver") or "3.8.6"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.0.10"
 
 local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
-
 local bufr_ver=os.getenv("bufr_ver") or "11.7.0"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
-local w3emc_ver=os.getenv("w3emc_ver") or "2.9.1"
+local w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 local sp_ver=os.getenv("sp_ver") or "2.3.3"
 local ip_ver=os.getenv("ip_ver") or "3.3.3"
 local sigio_ver=os.getenv("sigio_ver") or "2.3.2"
 local sfcio_ver=os.getenv("sfcio_ver") or "1.4.1"
-local nemsio_ver=os.getenv("nemsio_ver") or "2.5.2"
+local nemsio_ver=os.getenv("nemsio_ver") or "2.5.4"
 local wrf_io_ver=os.getenv("wrf_io_ver") or "1.2.0"
+local ncio_ver=os.getenv("ncio_ver") or "1.1.2"
 local crtm_ver=os.getenv("crtm_ver") or "2.4.0.1"
-local prod_util_ver=os.getenv("prod_util_ver") or "2.0.10"
+local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.1"
 
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
 load(pathJoin("intel", intel_ver))
@@ -29,8 +30,9 @@ load(pathJoin("cray-mpich", cray_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
 load(pathJoin("python", python_ver))
 
-load(pathJoin("netcdf", netcdf_ver))
+load(pathJoin("prod_util", prod_util_ver))
 
+load(pathJoin("netcdf", netcdf_ver))
 load(pathJoin("bufr", bufr_ver))
 load(pathJoin("bacio", bacio_ver))
 load(pathJoin("w3emc", w3emc_ver))
@@ -40,15 +42,8 @@ load(pathJoin("sigio", sigio_ver))
 load(pathJoin("sfcio", sfcio_ver))
 load(pathJoin("nemsio", nemsio_ver))
 load(pathJoin("wrf_io", wrf_io_ver))
+load(pathJoin("ncio", ncio_ver))
 load(pathJoin("crtm", crtm_ver))
-
-load(pathJoin("prod_util", prod_util_ver))
-
-pushenv("HPC_OPT", "/apps/ops/para/libs")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
-
-load("ncio/1.1.2")
-load("ncdiag/1.0.0")
+load(pathJoin("ncdiag",ncdiag_ver))
 
 whatis("Description: GSI utilities environment on WCOSS2")


### PR DESCRIPTION
This PR removes `/apps/ops/para/libs` from `gsiutils_wcoss2.intel.lua`.  Additionally module versions for w3emc, nemsio, and ncdiag are updated to be consistent with GSI [gsi_wcoss2.intel.lua](https://github.com/NOAA-EMC/GSI/blob/develop/modulefiles/gsi_wcoss2.intel.lua).

Resolves #20