### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -67,7 +67,6 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          sudo apt-get install cmake
           git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
           spack env create gsiutils-env gsi-utils/ci/spack.yaml

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -48,6 +48,7 @@ jobs:
           df -h
 
       - name: checkout  # This is for getting spack.yaml
+        if: steps.cache-env.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
             path: gsi-utils
@@ -66,17 +67,20 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
+          sudo apt-get install cmake
           git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
           spack env create gsiutils-env gsi-utils/ci/spack.yaml
           spack env activate gsiutils-env
+          spack compiler find
+          sudo apt install cmake
           spack external find
           spack add mpich@3.4.2
           spack concretize
           spack install -v --fail-fast --dirty
           spack clean --all
 
-  gsi-monitor:
+  gsi-utils:
     needs: setup
     runs-on: ubuntu-latest
 
@@ -99,10 +103,11 @@ jobs:
         run: |
           source spack/share/spack/setup-env.sh
           spack env activate gsiutils-env
-          export CC=mpicc
-          export FC=mpif90
           cd gsi-utils
           mkdir -p build && cd build
           cmake -DCMAKE_INSTALL_PREFIX=../install -DBUILD_UTIL_ALL=ON ..
           make -j2 VERBOSE=1
           make install
+        env:
+          CC: mpicc
+          FC: mpif90

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: checkout  # This is for getting spack.yaml
         if: steps.cache-env.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             path: gsi-utils
 
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             path: gsi-utils
 

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -13,8 +13,8 @@ env:
   CC: icc
   FC: ifort
   CXX: icpc
-  I_MPI_CC: mpiicc
-  I_MPI_F90: mpiifort
+  I_MPI_CC: icc
+  I_MPI_F90: ifort
 
 # A note on flushing Action cache and relevance to "cache_key" above.
 # There is no way to flush the Action cache, and hence a number (#) is appended
@@ -42,6 +42,7 @@ jobs:
           df -h
           sudo swapoff -a
           sudo rm -rf /swapfile
+          sudo rm -rf /usr_local_mv
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
@@ -81,6 +82,8 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
+          sudo mv /usr/local/ /usr_local_mv
+          sudo apt-get install cmake
           git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
           spack env create gsiutils-env gsi-utils/ci/spack.yaml

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -13,8 +13,8 @@ env:
   CC: icc
   FC: ifort
   CXX: icpc
-  I_MPI_CC: icc
-  I_MPI_F90: ifort
+  I_MPI_CC: mpiicc
+  I_MPI_F90: mpiifort
 
 # A note on flushing Action cache and relevance to "cache_key" above.
 # There is no way to flush the Action cache, and hence a number (#) is appended
@@ -41,7 +41,7 @@ jobs:
         run: |
           df -h
           sudo swapoff -a
-          sudo rm -f /swapfile
+          sudo rm -rf /swapfile
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # Free up disk space
@@ -51,7 +51,8 @@ jobs:
           df -h
 
       - name: checkout # This is for getting spack.yaml
-        uses: actions/checkout@v3
+        if: steps.cache-env.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
         with:
             path: gsi-utils
 
@@ -73,6 +74,7 @@ jobs:
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt-get update
           sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran-2023.2.1 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.2.1
+          sudo apt-get clean
           echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
 
       # Install dependencies using Spack
@@ -84,6 +86,7 @@ jobs:
           spack env create gsiutils-env gsi-utils/ci/spack.yaml
           spack env activate gsiutils-env
           spack compiler find
+          sudo apt install cmake
           spack external find
           spack add intel-oneapi-mpi
           spack concretize
@@ -92,7 +95,7 @@ jobs:
 
   gsi-utils:
     needs: setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: install-intel
@@ -100,7 +103,7 @@ jobs:
           echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
 
       - name: checkout-gsiutils
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             path: gsi-utils
 
@@ -118,10 +121,11 @@ jobs:
         run: |
           source spack/share/spack/setup-env.sh
           spack env activate gsiutils-env
-          export CC=mpiicc
-          export FC=mpiifort
           cd gsi-utils
           mkdir -p build && cd build
           cmake -DCMAKE_INSTALL_PREFIX=../install -DBUILD_UTIL_ALL=ON ..
           make -j2 VERBOSE=1
           make install
+        env:
+          CC: mpiicc
+          FC: mpiifort

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -21,7 +21,7 @@ spack:
   - crtm@2.4.0.1
   - ncio@1.1.2
   - gsi-ncdiag@1.1.2
-  - cmake@3.20.1
+  - cmake@3.23.1
   view: true
   concretizer:
     unify: when_possible

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -21,7 +21,6 @@ spack:
   - crtm@2.4.0.1
   - ncio@1.1.2
   - gsi-ncdiag@1.1.2
-  - cmake@3.23.1
   view: true
   concretizer:
     unify: when_possible


### PR DESCRIPTION
This fixes CI dependency builds for GCC and Intel workflows.  This is achieved by forcing clean dependency builds each time there is an update.