### PR TITLE
Add handling to calculate analysis and interplate increments for number

### DIFF
--- a/src/netcdf_io/calc_analysis.fd/inc2anl.f90
+++ b/src/netcdf_io/calc_analysis.fd/inc2anl.f90
@@ -14,21 +14,26 @@ module inc2anl
 
   public :: gen_anl, close_files
 
-  integer, parameter :: nincv=10
+  integer, parameter :: nincv=13
   character(len=7) :: incvars_nemsio(nincv), incvars_netcdf(nincv), incvars_ncio(nincv)
-  integer, parameter :: nnciov=20
+  integer, parameter :: nnciov=22
   character(len=7) :: iovars_netcdf(nnciov)
 
   data incvars_nemsio / 'ugrd   ', 'vgrd   ', 'dpres  ', 'delz   ', 'o3mr   ',&
-                        'tmp    ', 'spfh   ', 'clwmr  ', 'icmr   ', 'pres   '/
+                        'tmp    ', 'spfh   ', 'clwmr  ', 'icmr   ', 'rwmr   ',&
+                        'snmr   ', 'grle   ', 'pres   '/
   data incvars_netcdf / 'u      ', 'v      ', 'delp   ', 'delz   ', 'o3mr   ',&
-                        'T      ', 'sphum  ', 'liq_wat', 'icmr   ', 'pres   '/
-  data incvars_ncio / 'ugrd   ', 'vgrd   ', 'dpres  ', 'delz   ', 'o3mr   ',&
-                        'tmp    ', 'spfh   ', 'clwmr  ', 'icmr   ', 'pressfc'/
+                        'T      ', 'sphum  ', 'liq_wat', 'icmr   ', 'rwmr   ',&
+                        'snmr   ', 'grle   ', 'pres   '/
+  data incvars_ncio /   'ugrd   ', 'vgrd   ', 'dpres  ', 'delz   ', 'o3mr   ',&
+                        'tmp    ', 'spfh   ', 'clwmr  ', 'icmr   ', 'rwmr   ',&
+                        'snmr   ', 'grle   ', 'pressfc'/
   data iovars_netcdf /  'grid_xt', 'grid_yt', 'pfull  ', 'phalf  ', 'clwmr  ',&
                         'delz   ', 'dpres  ', 'dzdt   ', 'grle   ', 'hgtsfc ',&
                         'icmr   ', 'o3mr   ', 'pressfc', 'rwmr   ', 'snmr   ',&
-                        'spfh   ', 'tmp    ', 'ugrd   ', 'vgrd   ', 'cld_amt'/
+                        'spfh   ', 'tmp    ', 'ugrd   ', 'vgrd   ', 'cld_amt',&
+                        'nccice ', 'nconrd '/
+
 
 contains
   subroutine gen_anl

--- a/src/netcdf_io/interp_inc.fd/driver.F90
+++ b/src/netcdf_io/interp_inc.fd/driver.F90
@@ -30,7 +30,7 @@
 
  implicit none
 
- integer, parameter :: num_recs = 9
+ integer, parameter :: num_recs = 12
 
 ! Declare externals
  external :: w3tagb, netcdf_err, splat, w3tage
@@ -57,6 +57,7 @@
  integer :: id_t_inc_out, id_sphum_inc_out
  integer :: id_liq_wat_inc_out, id_o3mr_inc_out
  integer :: id_icmr_inc_out, id_dim
+ integer :: id_rwmr_inc_out, id_snmr_inc_out, id_grle_inc_out
  integer :: header_buffer_val = 16384
  integer :: kgds_in(200), kgds_out(200)
  integer :: ip, ipopt(20), no
@@ -79,7 +80,8 @@
 
  ! NOTE: u_inc,v_inc must be consecutive
  data records /'u_inc', 'v_inc', 'delp_inc', 'delz_inc', 'T_inc', &
-               'sphum_inc', 'liq_wat_inc', 'o3mr_inc', 'icmr_inc' /
+               'sphum_inc', 'liq_wat_inc', 'o3mr_inc', 'icmr_inc', &
+               'rwmr_inc', 'snmr_inc', 'grle_inc' /
 
  namelist /setup/ lon_out, lat_out, outfile, infile, lev
 
@@ -187,7 +189,16 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
   
    error = nf90_def_var(ncid_out, 'icmr_inc', nf90_float, (/dim_lon_out,dim_lat_out,dim_lev_out/), id_icmr_inc_out)
    call netcdf_err(error, 'defining variable icmr_inc for file='//trim(outfile) )
+
+   error = nf90_def_var(ncid_out, 'rwmr_inc', nf90_float, (/dim_lon_out,dim_lat_out,dim_lev_out/), id_rwmr_inc_out)
+   call netcdf_err(error, 'defining variable rwmr_inc for file='//trim(outfile) )
   
+   error = nf90_def_var(ncid_out, 'snmr_inc', nf90_float, (/dim_lon_out,dim_lat_out,dim_lev_out/), id_snmr_inc_out)
+   call netcdf_err(error, 'defining variable snmr_inc for file='//trim(outfile) )
+
+   error = nf90_def_var(ncid_out, 'grle_inc', nf90_float, (/dim_lon_out,dim_lat_out,dim_lev_out/), id_grle_inc_out)
+   call netcdf_err(error, 'defining variable grle_inc for file='//trim(outfile) )
+
    error = nf90_put_att(ncid_out, nf90_global, 'source', 'GSI')
    call netcdf_err(error, 'defining source attribute for file='//trim(outfile) )
   
@@ -354,7 +365,6 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
      call netcdf_err(error, 'inquiring ' // trim(records(rec)) // ' id for file='//trim(infile) )
      error = nf90_get_var(ncid_in, id_var, dummy_in)
      call netcdf_err(error, 'reading ' //  trim(records(rec)) // ' for file='//trim(infile) )
-  
   
      ip = 0 ! bilinear
      ipopt = 0


### PR DESCRIPTION
The fv3 model uses Thompson scheme and therefore, there are two prognostic cloud-related variables:
- number concentration of cloud ice (ni)
- number concentration of rain (nr)

The GSI interface has updated to read in these two extra variables and  therefore, the gdas.t${cyc}.atmf{fhr}.nc files have the following two additional fields: nccice (ni) and nconrd (nr)

```
        float nccice(time, pfull, grid_yt, grid_xt) ;
                nccice:_FillValue = 9.99e+20f ;
                nccice:cell_methods = "time: point" ;
                nccice:long_name = "cloud ice water number concentration" ;
                nccice:missing_value = 9.99e+20f ;
                nccice:output_file = "atm" ;
                nccice:units = "/kg" ;
        float nconrd(time, pfull, grid_yt, grid_xt) ;
                nconrd:_FillValue = 9.99e+20f ;
                nconrd:cell_methods = "time: point" ;
                nconrd:long_name = "rain number concentration" ;
                nconrd:missing_value = 9.99e+20f ;
                nconrd:output_file = "atm" ;
                nconrd:units = "/kg" ;
```
Currently, the `atmanl` file includes `nccice` and `nconrd` but they are missing values. 
For consistency, the related output gdas.t${cyc}.atmanl.nc should have valid values for nccice (ni) and nconrd (nr).

The number concentration of ice and rain are not control variables, and therefore, there are no increments associated with them.  But the output atmanl should have valid values for them copied from the input guess fields.  

In addition, the precipitation variables (rain, snow and graupel) are added to the interpolation routine for resolution change.  Currently, the cloud and precipitation increments are zero.  This update is to prepare for future testing when we want to pass the cloud and precipitation increments back to the model.  

This PR has a related PR in [global-workflow #2648](https://github.com/NOAA-EMC/global-workflow/pull/2648)
The number MPI declared need to be increased from 10 to 13 in the python script which runs this utility