### PR TITLE
Move to contrib spack-stack on Jet

### DIFF
--- a/modulefiles/gsiutils_jet.intel.lua
+++ b/modulefiles/gsiutils_jet.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-intel/install/modulefiles/Core")
 
 local python_ver=os.getenv("python_ver") or "3.11.6"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"


### PR DESCRIPTION
# Description
- Update Jet module file to use /contrib installation of spack-stack;
- Following the failure of the lfs4 storage, spack stack was moved to /contrib and present module file no longer works

  Resolves #51 
  Refs NOAA-EMC/global-workflow#2841
