### PR TITLE
Add/fix build capability for Gaea-C5, Gaea-C6, and container

### DIFF
--- a/modulefiles/gsiutils_container.intel.lua
+++ b/modulefiles/gsiutils_container.intel.lua
@@ -1,0 +1,23 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/opt/spack-stack/spack-stack-1.8.0/envs/unified-env/install/modulefiles/Core")
+
+--local python_ver=os.getenv("python_ver") or "3.11.6"
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.12.2"
+local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load("gsiutils_common")
+
+load(pathJoin("prod_util", prod_util_ver))
+
+pushenv("CFLAGS", "-march=ivybridge")
+pushenv("FFLAGS", "-march=ivybridge")
+
+whatis("Description: GSI utilities environment in a container with Intel Compilers")

--- a/modulefiles/gsiutils_gaeac5.intel.lua
+++ b/modulefiles/gsiutils_gaeac5.intel.lua
@@ -4,8 +4,8 @@ help([[
 prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
 
 local python_ver=os.getenv("python_ver") or "3.11.6"
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.1.0"
-local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.25"
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
@@ -21,4 +21,4 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-whatis("Description: GSI utilities environment on Gaea with Intel Compilers")
+whatis("Description: GSI utilities environment on GaeaC5 with Intel Compilers")

--- a/modulefiles/gsiutils_gaeac6.intel.lua
+++ b/modulefiles/gsiutils_gaeac6.intel.lua
@@ -1,0 +1,24 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
+
+local python_ver=os.getenv("python_ver") or "3.11.6"
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
+local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
+load(pathJoin("python", python_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load("gsiutils_common")
+
+load(pathJoin("prod_util", prod_util_ver))
+
+pushenv("CFLAGS", "-xHOST")
+pushenv("FFLAGS", "-xHOST")
+
+whatis("Description: GSI utilities environment on GaeaC5 with Intel Compilers")

--- a/modulefiles/gsiutils_gaeac6.intel.lua
+++ b/modulefiles/gsiutils_gaeac6.intel.lua
@@ -21,4 +21,4 @@ load(pathJoin("prod_util", prod_util_ver))
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 
-whatis("Description: GSI utilities environment on GaeaC5 with Intel Compilers")
+whatis("Description: GSI utilities environment on GaeaC6 with Intel Compilers")

--- a/modulefiles/gsiutils_gaeac6.intel.lua
+++ b/modulefiles/gsiutils_gaeac6.intel.lua
@@ -1,11 +1,11 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.6.0/envs/gsi-addon/install/modulefiles/Core")
 
 local python_ver=os.getenv("python_ver") or "3.11.6"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
-local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.29"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -21,8 +21,11 @@ case $(hostname -f) in
   dlogin0[1-9].dogwood.wcoss2.ncep.noaa.gov) MACHINE_ID=wcoss2 ;; ### dogwood01-9
   dlogin10.dogwood.wcoss2.ncep.noaa.gov)     MACHINE_ID=wcoss2 ;; ### dogwood10
 
-  gaea5[1-8])          MACHINE_ID=gaea ;; ### gaea51-58
-  gaea5[1-8].ncrc.gov) MACHINE_ID=gaea ;; ### gaea51-58
+  gaea5[1-8])          MACHINE_ID=gaeac5 ;; ### gaea51-58
+  gaea5[1-8].ncrc.gov) MACHINE_ID=gaeac5 ;; ### gaea51-58
+
+  gaea6[1-8])          MACHINE_ID=gaeac6 ;; ### gaea61-68
+  gaea6[1-8].ncrc.gov) MACHINE_ID=gaeac6 ;; ### gaea61-68
 
   hfe0[1-9]) MACHINE_ID=hera ;; ### hera01-09
   hfe1[0-2]) MACHINE_ID=hera ;; ### hera10-12
@@ -81,9 +84,12 @@ elif [[ -d /work ]]; then
   else
     MACHINE_ID=orion
   fi
-elif [[ -d /gpfs && -d /ncrc ]]; then
-  # We are on GAEA.
-  MACHINE_ID=gaea
+elif [[ -d /gpfs/f5 ]]; then
+  # We are on GAEAC5.
+  MACHINE_ID=gaeac5
+elif [[ -d /gpfs/f6 ]]; then
+  # We are on GAEAC6.
+  MACHINE_ID=gaeac6
 elif [[ -d /data/prod ]]; then
   # We are on SSEC's S4
   MACHINE_ID=s4

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -48,7 +48,7 @@ case $(hostname -f) in
   *) MACHINE_ID=UNKNOWN ;;  # Unknown platform
 esac
 
-if [[ ${MACHINE_ID} == "UNKNOWN" ]]; then 
+if [[ ${MACHINE_ID} == "UNKNOWN" ]]; then
    case ${PW_CSP:-} in
       "aws" | "google" | "azure") MACHINE_ID=noaacloud ;;
       *) PW_CSP="UNKNOWN"
@@ -80,8 +80,8 @@ elif [[ -d /scratch1 ]]; then
   MACHINE_ID=hera
 elif [[ -d /work ]]; then
   # We are on MSU Orion or Hercules
-  if [[ -d /apps/other ]]; then
-    # We are on Hercules
+  mount=$(findmnt -n -o SOURCE /home)
+  if [[ ${mount} =~ "hercules" ]]; then
     MACHINE_ID=hercules
   else
     MACHINE_ID=orion

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -45,7 +45,7 @@ case $(hostname -f) in
   *) MACHINE_ID=UNKNOWN ;;  # Unknown platform
 esac
 
-if [[ ${MACHINE_ID} == "UNKNOWN" ]]; then
+if [[ ${MACHINE_ID} == "UNKNOWN" ]]; then 
    case ${PW_CSP:-} in
       "aws" | "google" | "azure") MACHINE_ID=noaacloud ;;
       *) PW_CSP="UNKNOWN"
@@ -61,7 +61,9 @@ if [[ "${MACHINE_ID}" != "UNKNOWN" ]]; then
 fi
 
 # Try searching based on paths since hostname may not match on compute nodes
-if [[ -d /lfs/h3 ]]; then
+if [[ -d /opt/spack-stack ]]; then
+  MACHINE_ID=container
+elif [[ -d /lfs/h3 ]]; then
   # We are on NOAA Cactus or Dogwood
   MACHINE_ID=wcoss2
 elif [[ -d /lfs/h1 && ! -d /lfs/h3 ]]; then
@@ -75,8 +77,8 @@ elif [[ -d /scratch1 ]]; then
   MACHINE_ID=hera
 elif [[ -d /work ]]; then
   # We are on MSU Orion or Hercules
-  mount=$(findmnt -n -o SOURCE /home)
-  if [[ ${mount} =~ "hercules" ]]; then
+  if [[ -d /apps/other ]]; then
+    # We are on Hercules
     MACHINE_ID=hercules
   else
     MACHINE_ID=orion

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -40,6 +40,7 @@ elif [[ $MACHINE_ID = s4* ]] ; then
         source /usr/share/lmod/lmod/init/bash
     fi
     module purge
+
 elif [[ $MACHINE_ID = wcoss2 ]]; then
     # We are on WCOSS2
     module reset
@@ -67,33 +68,8 @@ elif [[ $MACHINE_ID = gaea* ]] ; then
         # the module command fails.  Hence we actually have to source
         # /etc/profile here.
         source /etc/profile
-        __ms_source_etc_profile=yes
-    else
-        __ms_source_etc_profile=no
     fi
-    module purge
-    # clean up after purge
-    unset _LMFILES_
-    unset _LMFILES_000
-    unset _LMFILES_001
-    unset LOADEDMODULES
-    module load modules
-    if [[ -d /opt/cray/ari/modulefiles ]] ; then
-        module use -a /opt/cray/ari/modulefiles
-    fi
-    if [[ -d /opt/cray/pe/ari/modulefiles ]] ; then
-        module use -a /opt/cray/pe/ari/modulefiles
-    fi
-    if [[ -d /opt/cray/pe/craype/default/modulefiles ]] ; then
-        module use -a /opt/cray/pe/craype/default/modulefiles
-    fi
-    if [[ -s /etc/opt/cray/pe/admin-pe/site-config ]] ; then
-        source /etc/opt/cray/pe/admin-pe/site-config
-    fi
-    if [[ "$__ms_source_etc_profile" == yes ]] ; then
-        source /etc/profile
-        unset __ms_source_etc_profile
-    fi
+    module reset
 
 elif [[ $MACHINE_ID = expanse* ]]; then
     # We are on SDSC Expanse

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -7,6 +7,11 @@ if [[ $MACHINE_ID = jet* ]] ; then
         source /apps/lmod/lmod/init/bash
     fi
     module purge
+elif [[ $MACHINE_ID = container* ]] ; then
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /usr/lmod/lmod/init/bash
+    fi
+    module purge
 
 elif [[ $MACHINE_ID = hera* ]] ; then
     # We are on NOAA Hera
@@ -35,7 +40,6 @@ elif [[ $MACHINE_ID = s4* ]] ; then
         source /usr/share/lmod/lmod/init/bash
     fi
     module purge
-
 elif [[ $MACHINE_ID = wcoss2 ]]; then
     # We are on WCOSS2
     module reset
@@ -63,8 +67,33 @@ elif [[ $MACHINE_ID = gaea* ]] ; then
         # the module command fails.  Hence we actually have to source
         # /etc/profile here.
         source /etc/profile
+        __ms_source_etc_profile=yes
+    else
+        __ms_source_etc_profile=no
     fi
-    module reset
+    module purge
+    # clean up after purge
+    unset _LMFILES_
+    unset _LMFILES_000
+    unset _LMFILES_001
+    unset LOADEDMODULES
+    module load modules
+    if [[ -d /opt/cray/ari/modulefiles ]] ; then
+        module use -a /opt/cray/ari/modulefiles
+    fi
+    if [[ -d /opt/cray/pe/ari/modulefiles ]] ; then
+        module use -a /opt/cray/pe/ari/modulefiles
+    fi
+    if [[ -d /opt/cray/pe/craype/default/modulefiles ]] ; then
+        module use -a /opt/cray/pe/craype/default/modulefiles
+    fi
+    if [[ -s /etc/opt/cray/pe/admin-pe/site-config ]] ; then
+        source /etc/opt/cray/pe/admin-pe/site-config
+    fi
+    if [[ "$__ms_source_etc_profile" == yes ]] ; then
+        source /etc/profile
+        unset __ms_source_etc_profile
+    fi
 
 elif [[ $MACHINE_ID = expanse* ]]; then
     # We are on SDSC Expanse


### PR DESCRIPTION
After the recent Gaea-C5 OS upgrade, gsi-utils fails to build.
This issues corrects Gaea-C5 build, adds Gaea-C6 build capability (following [ufs-wx-model](https://github.com/ufs-community/ufs-weather-model/pull/2448)), and adds containerized build capability.

Refs NOAA-EMC/global-workflow [#3011](https://github.com/NOAA-EMC/global-workflow/issues/3011)
Refs NOAA-EMC/global-workflow [#3025](https://github.com/NOAA-EMC/global-workflow/issues/3025)
Refs #54 