### PR TITLE
Calc_analysis fix for delp increment read to allow C1152 cycling (#56)

### DIFF
--- a/src/netcdf_io/calc_analysis.fd/inc2anl.f90
+++ b/src/netcdf_io/calc_analysis.fd/inc2anl.f90
@@ -347,14 +347,16 @@ contains
     real, allocatable, dimension(:,:,:) :: work3d_inc
     real, allocatable, dimension(:,:) :: ps_inc, work2d
     real, allocatable, dimension(:) :: bk5, work1d
-    integer :: iret, j, jj
+    integer :: iret, j, jj, k
     type(Dataset) :: incncfile
 
     ! get bk5 from attributes
     call read_attribute(fcstncfile, 'bk', bk5)
     ! read in delp increment to get ps increment
     incncfile = open_dataset(incr_file)
-    call read_vardata(incncfile, 'delp_inc', work3d_inc)
+    do k=1,nlev
+       call read_vardata(incncfile, 'delp_inc', work3d_inc, nslice=k, slicedim=3)
+    enddo
     ! get ps increment from delp increment and bk
     allocate(ps_inc(nlon,nlat))
     ps_inc(:,:) = work3d_inc(:,:,nlev) / (bk5(nlev) - bk5(nlev-1))


### PR DESCRIPTION
When running calc_analysis for C1152, the job fails in the read of the delp increment:
```
call read_vardata(incncfile, 'delp_inc', work3d_inc)
```
This read has a different format than the other 3d increment reads:
```
call read_vardata(incncfile, trim(incvar)//"_inc", work3d_inc_gsi, nslice=k, slicedim=3)
```
Adding `nslice=k, slicedim=3` to the delp_inc read along with a do loop over k allows the job to succeed.

This fix was previously tested for 3 full cycles on WCOSS2 for a C1152/C384 ATM-only experiment.