### PR TITLE
update hera gnu spack-stack path and modulefile typo

### DIFF
--- a/modulefiles/gsiutils_hera.gnu.lua
+++ b/modulefiles/gsiutils_hera.gnu.lua
@@ -1,11 +1,11 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch4/NCEPDEV/stmp/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local python_ver=os.getenv("python_ver") or "3.11.6"
-local stack_intel_ver=os.getenv("stack_gcc_ver") or "9.2.0"
-local stack_impi_ver=os.getenv("stack_openmpi_ver") or "4.1.5"
+local stack_gcc_ver=os.getenv("stack_gcc_ver") or "9.2.0"
+local stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.6"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 local openblas_ver=os.getenv("cmake_ver") or "0.3.24"
 


### PR DESCRIPTION
This PR enables the gnu build of GSI-utils on Hera by 
 - updating the spack-stack/1.6.0 `MODULEPATH`
 - replacing _intel_ variables with _gnu_ variables

in `modulefiles/gsiutils_hera.gnu.lua`

Resolves #66