### PR TITLE
Make GSI-utils working with Rocky 8 on CSPs

### DIFF
--- a/modulefiles/gsiutils_noaacloud.intel.lua
+++ b/modulefiles/gsiutils_noaacloud.intel.lua
@@ -1,0 +1,29 @@
+help([[
+GSI utilities environment on NOAA Cloud with Intel Compilers
+]])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/modules/modulefiles")
+
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
+local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+
+load("gnu")
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+unload("gnu")
+
+local stack_python_ver=os.getenv("python_ver") or "3.11.6"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+
+load(pathJoin("python", stack_python_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load("gsiutils_common")
+load(pathJoin("prod_util", prod_util_ver))
+
+pushenv("CFLAGS", "-xHOST")
+pushenv("FFLAGS", "-xHOST")
+
+whatis("Description: GSI utilities environment on NOAA Cloud with Intel Compilers")


### PR DESCRIPTION
On CSPs, OS had moved from CentOS to Rocky 8, we need to update modulefiles to compile with Rocky 8 on CSPs.

This PR will resolve issue #70