### PR TITLE
Unload cray-libsci on C6

### DIFF
--- a/modulefiles/gsiutils_gaeac6.intel.lua
+++ b/modulefiles/gsiutils_gaeac6.intel.lua
@@ -18,6 +18,8 @@ load("gsiutils_common")
 
 load(pathJoin("prod_util", prod_util_ver))
 
+unload("cray-libsci")
+
 pushenv("CFLAGS", "-xHOST")
 pushenv("FFLAGS", "-xHOST")
 


### PR DESCRIPTION
After maintenance on 6/16/2025, C6 now loads the cray-libsci module, which causes build problems.  This module needs to be unloaded before building gsi-utils.

Refs noaa-emc/global-workflow#3820