### PR TITLE
Port to Ursa

### DIFF
--- a/modulefiles/gsiutils_ursa.intel.lua
+++ b/modulefiles/gsiutils_ursa.intel.lua
@@ -1,0 +1,28 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+
+local python_ver=os.getenv("python_ver") or "3.11.7"
+local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
+local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"
+local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
+load(pathJoin("python", python_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load("gsiutils_common")
+
+load(pathJoin("prod_util", prod_util_ver))
+
+pushenv("CFLAGS", "-xHOST")
+pushenv("FFLAGS", "-xHOST")
+
+setenv("CC","mpiicc")
+setenv("CXX","mpiicpc")
+setenv("FC","mpiifort")
+
+whatis("Description: GSI utilities environment on Hera with Intel Compilers")

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -31,6 +31,10 @@ case $(hostname -f) in
   hfe1[0-2]) MACHINE_ID=hera ;; ### hera10-12
   hecflow01) MACHINE_ID=hera ;; ### heraecflow01
 
+  ufe0[1-9]) MACHINE_ID=ursa ;; ### ursa01-09
+  ufe1[0-6]) MACHINE_ID=ursa ;; ### ursa10-12
+  uecflow01) MACHINE_ID=ursa ;; ### ursaecflow01
+
   s4-submit.ssec.wisc.edu) MACHINE_ID=s4 ;; ### s4
 
   fe[1-8]) MACHINE_ID=jet ;; ### jet01-8
@@ -72,12 +76,17 @@ elif [[ -d /lfs/h3 ]]; then
 elif [[ -d /lfs/h1 && ! -d /lfs/h3 ]]; then
   # We are on NOAA TDS Acorn
   MACHINE_ID=acorn
-elif [[ -d /mnt/lfs1 ]]; then
+elif [[ -d /mnt/lfs5 ]]; then
   # We are on NOAA Jet
   MACHINE_ID=jet
-elif [[ -d /scratch1 ]]; then
-  # We are on NOAA Hera
-  MACHINE_ID=hera
+elif [[ -d /scratch3 ]]; then
+  # We are on NOAA Hera or Ursa
+  mount=$(findmnt -n -o SOURCE /home)
+  if [[ ${mount} =~ "ursa" ]]; then
+    MACHINE_ID=ursa
+  else
+    MACHINE_ID=hera
+  fi
 elif [[ -d /work ]]; then
   # We are on MSU Orion or Hercules
   mount=$(findmnt -n -o SOURCE /home)

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -13,8 +13,8 @@ elif [[ $MACHINE_ID = container* ]] ; then
     fi
     module purge
 
-elif [[ $MACHINE_ID = hera* ]] ; then
-    # We are on NOAA Hera
+elif [[ $MACHINE_ID = hera* || $MACHINE_ID = ursa* ]] ; then
+    # We are on NOAA Hera or Ursa
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /apps/lmod/lmod/init/bash
     fi


### PR DESCRIPTION
This ports GSI-utils to Ursa.  The utilities build successfully on Ursa, but have not yet been tested.  Testing will need to be completed in the global-workflow.