### PR TITLE
Update module files to match GSI-monitor, GSI, and global-workflow

### DIFF
--- a/modulefiles/gsiutils_wcoss2.intel.lua
+++ b/modulefiles/gsiutils_wcoss2.intel.lua
@@ -3,10 +3,9 @@ help([[
 
 local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
-local craype_ver=os.getenv("craype_ver") or "2.7.8"
-local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
+local craype_ver=os.getenv("craype_ver") or "2.7.13"
+local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.9"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
-local python_ver=os.getenv("python_ver") or "3.8.6"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.0.10"
 
 local hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
@@ -29,7 +28,6 @@ load(pathJoin("intel", intel_ver))
 load(pathJoin("craype", craype_ver))
 load(pathJoin("cray-mpich", cray_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
-load(pathJoin("python", python_ver))
 
 load(pathJoin("prod_util", prod_util_ver))
 


### PR DESCRIPTION
This PR updates the craype and cray_mpich versions for WCOSS2 so that they are the same across the GSI, GSI-monitor, GSI-utils, and global workflow branches.  This also removes the Python module as it should not be loaded at compile time.

Prerequisite for https://github.com/NOAA-EMC/global-workflow/issues/4044