### PR TITLE
porting GSI-utils to native AWS

### DIFF
--- a/modulefiles/gsiutils_aws-ec2.intel.lua
+++ b/modulefiles/gsiutils_aws-ec2.intel.lua
@@ -1,0 +1,21 @@
+help([[
+GSI utilities environment on AWS ec2 with Intel Compilers
+]])
+
+prepend_path("MODULEPATH", "/opt/spack-stack/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/opt/modulefiles")
+
+stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
+stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
+cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load("gsiutils_common")
+
+pushenv("CFLAGS", "-xHOST")
+pushenv("FFLAGS", "-xHOST")
+
+whatis("Description: GSI utilities environment on AWS ec2 with Intel Compilers")

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -37,6 +37,8 @@ case $(hostname -f) in
 
   s4-submit.ssec.wisc.edu) MACHINE_ID=s4 ;; ### s4
 
+  ip-*) MACHINE_ID=aws-ec2 ;; ### aws-ec2
+
   fe[1-8]) MACHINE_ID=jet ;; ### jet01-8
   tfe[12]) MACHINE_ID=jet ;; ### tjet1-2
 
@@ -68,8 +70,10 @@ if [[ "${MACHINE_ID}" != "UNKNOWN" ]]; then
 fi
 
 # Try searching based on paths since hostname may not match on compute nodes
-if [[ -d /opt/spack-stack ]]; then
+if [[ -v SINGULARITY_NAME ]]; then
   MACHINE_ID=container
+elif [[ -d /opt/spack-stack ]]; then
+  MACHINE_ID=aws-ec2
 elif [[ -d /lfs/h3 ]]; then
   # We are on NOAA Cactus or Dogwood
   MACHINE_ID=wcoss2

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -46,6 +46,8 @@ case $(hostname -f) in
   s4-submit.ssec.wisc.edu) MACHINE_ID=s4 ;; ### s4
 
   ip-*) MACHINE_ID=aws-ec2 ;; ### aws-ec2
+  compute-dy-*) MACHINE_ID=aws-ec2 ;; ### aws-ec2
+  processing-dy-*) MACHINE_ID=aws-ec2 ;; ### aws-ec2
 
   fe[1-8]) MACHINE_ID=jet ;; ### jet01-8
   tfe[12]) MACHINE_ID=jet ;; ### tjet1-2
@@ -80,7 +82,7 @@ fi
 # Try searching based on paths since hostname may not match on compute nodes
 if [[ -v SINGULARITY_NAME ]]; then
   MACHINE_ID=container
-elif [[ -d /opt/spack-stack ]]; then
+elif [[ -d /opt/spack-stack && -d /lustre ]]; then
   MACHINE_ID=aws-ec2
 elif [[ -d /lfs/h3 ]]; then
   # We are on NOAA Cactus or Dogwood

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -7,9 +7,16 @@ if [[ $MACHINE_ID = jet* ]] ; then
         source /apps/lmod/lmod/init/bash
     fi
     module purge
+
 elif [[ $MACHINE_ID = container* ]] ; then
     if ( ! eval module help > /dev/null 2>&1 ) ; then
         source /usr/lmod/lmod/init/bash
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = aws-ec2* ]] ; then
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /usr/share/lmod/lmod/init/bash
     fi
     module purge
 


### PR DESCRIPTION
In order to porting GSI-utils to native AWS, we need to do:

1. Add module files for native AWS
2. detect native AWS (machine_ID)
3. setup modules (using module files for native AWS)

code compiled on native AWS successfully.
GW low-res cases run fine on native AWS.

close issue #94 